### PR TITLE
Update to net8

### DIFF
--- a/WebBMI/HealthMgr/HealthMgr.csproj
+++ b/WebBMI/HealthMgr/HealthMgr.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/WebBMI/HealthMgrTests/HealthMgrTests.csproj
+++ b/WebBMI/HealthMgrTests/HealthMgrTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/WebBMI/WebBMI/WebBMI.csproj
+++ b/WebBMI/WebBMI/WebBMI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- bump target framework to net8.0 for WebBMI, HealthMgr and tests

## Testing
- `dotnet build WebBMI/WebBMI.sln` *(fails: `dotnet` not found)*