### PR TITLE
Update GitHub Actions for .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,14 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '3.1.x'
-    - name: Install libssl1.1
-      run: sudo apt-get update && sudo apt-get install -y libssl1.1
+        dotnet-version: '8.0.x'
     - name: Restore dependencies
       run: dotnet restore WebBMI/WebBMI.sln
     - name: Build


### PR DESCRIPTION
## Summary
- update workflow to use `actions/setup-dotnet@v4`
- target .NET 8
- simplify runner and remove obsolete OpenSSL install

## Testing
- `dotnet --version` *(fails: command not found)*