### PR TITLE
Fix BMI calculation and pass tests

### DIFF
--- a/WebBMI/HealthMgr/BmiCalculator.cs
+++ b/WebBMI/HealthMgr/BmiCalculator.cs
@@ -19,11 +19,10 @@ namespace HealthMgr
 
         public float Calculate()
         {
-            float result = 0;
-            //將float改成int試試看
-            float height = (int)Height / 100;
-            result = Weight / (height * height);
-
+            // Calculate BMI using floating point division to avoid
+            // truncation from integer math.
+            float height = (float)Height / 100f;
+            float result = Weight / (height * height);
             return result;
         }
     }


### PR DESCRIPTION
## Summary
- fix BMI calculator height division using float

## Testing
- `dotnet test --no-build --verbosity normal WebBMI/WebBMI.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685d4ed68e04833090c3f93ddbd27e3c